### PR TITLE
feat: Render MEF static objects from QSC scripts

### DIFF
--- a/bin/config.ini
+++ b/bin/config.ini
@@ -1,0 +1,2 @@
+[Paths]
+MEFPath=res/missions/location0/common/objects/

--- a/shaders/41/object.frag
+++ b/shaders/41/object.frag
@@ -7,7 +7,6 @@ out vec4 out_color;
 
 void main() {
 	vec3 light_dir = normalize(vec3(0.5, 1.0, 0.5));
-	vec3 n = normalize(v_normal);
-	float diffuse = max(dot(n, light_dir), 0.2);
+	float diffuse = max(dot(v_normal, light_dir), 0.2);
 	out_color = vec4(vec3(0.8) * diffuse, 1.0);
 }

--- a/shaders/41/object.frag
+++ b/shaders/41/object.frag
@@ -1,0 +1,12 @@
+#version 410
+
+in vec3 v_normal;
+in vec2 v_uv;
+
+out vec4 out_color;
+
+void main() {
+	vec3 light_dir = normalize(vec3(0.5, 1.0, 0.5));
+	float diffuse = max(dot(v_normal, light_dir), 0.2);
+	out_color = vec4(vec3(0.8) * diffuse, 1.0);
+}

--- a/shaders/41/object.frag
+++ b/shaders/41/object.frag
@@ -7,6 +7,7 @@ out vec4 out_color;
 
 void main() {
 	vec3 light_dir = normalize(vec3(0.5, 1.0, 0.5));
-	float diffuse = max(dot(v_normal, light_dir), 0.2);
+	vec3 n = normalize(v_normal);
+	float diffuse = max(dot(n, light_dir), 0.2);
 	out_color = vec4(vec3(0.8) * diffuse, 1.0);
 }

--- a/shaders/41/object.vert
+++ b/shaders/41/object.vert
@@ -17,7 +17,6 @@ out vec2 v_uv;
 
 void main() {
 	gl_Position = mvp_objects * u_model_mat * vec4(in_pos, 1.0);
-	mat3 normal_mat = mat3(transpose(inverse(u_model_mat)));
-	v_normal = normalize(normal_mat * in_normal);
+	v_normal = in_normal;
 	v_uv = in_uv;
 }

--- a/shaders/41/object.vert
+++ b/shaders/41/object.vert
@@ -1,0 +1,22 @@
+#version 410
+
+layout(location = 0) in vec3 in_pos;
+layout(location = 1) in vec3 in_normal;
+layout(location = 2) in vec2 in_uv;
+
+layout(std140) uniform ubo_mats {
+	mat4 mvp_mat_follow_view;
+	mat4 mvp_flat_sky_layer;
+	mat4 mvp_objects;
+};
+
+uniform mat4 u_model_mat;
+
+out vec3 v_normal;
+out vec2 v_uv;
+
+void main() {
+	gl_Position = mvp_objects * u_model_mat * vec4(in_pos, 1.0);
+	v_normal = in_normal;
+	v_uv = in_uv;
+}

--- a/shaders/41/object.vert
+++ b/shaders/41/object.vert
@@ -17,6 +17,7 @@ out vec2 v_uv;
 
 void main() {
 	gl_Position = mvp_objects * u_model_mat * vec4(in_pos, 1.0);
-	v_normal = in_normal;
+	mat3 normal_mat = mat3(transpose(inverse(u_model_mat)));
+	v_normal = normalize(normal_mat * in_normal);
 	v_uv = in_uv;
 }

--- a/shaders/45/object.frag
+++ b/shaders/45/object.frag
@@ -7,7 +7,6 @@ out vec4 out_color;
 
 void main() {
 	vec3 light_dir = normalize(vec3(0.5, 1.0, 0.5));
-	vec3 n = normalize(v_normal);
-	float diffuse = max(dot(n, light_dir), 0.2);
+	float diffuse = max(dot(v_normal, light_dir), 0.2);
 	out_color = vec4(vec3(0.8) * diffuse, 1.0);
 }

--- a/shaders/45/object.frag
+++ b/shaders/45/object.frag
@@ -1,0 +1,12 @@
+#version 450
+
+in vec3 v_normal;
+in vec2 v_uv;
+
+out vec4 out_color;
+
+void main() {
+	vec3 light_dir = normalize(vec3(0.5, 1.0, 0.5));
+	float diffuse = max(dot(v_normal, light_dir), 0.2);
+	out_color = vec4(vec3(0.8) * diffuse, 1.0);
+}

--- a/shaders/45/object.frag
+++ b/shaders/45/object.frag
@@ -7,6 +7,7 @@ out vec4 out_color;
 
 void main() {
 	vec3 light_dir = normalize(vec3(0.5, 1.0, 0.5));
-	float diffuse = max(dot(v_normal, light_dir), 0.2);
+	vec3 n = normalize(v_normal);
+	float diffuse = max(dot(n, light_dir), 0.2);
 	out_color = vec4(vec3(0.8) * diffuse, 1.0);
 }

--- a/shaders/45/object.vert
+++ b/shaders/45/object.vert
@@ -17,7 +17,6 @@ out vec2 v_uv;
 
 void main() {
 	gl_Position = mvp_objects * u_model_mat * vec4(in_pos, 1.0);
-	mat3 normal_mat = mat3(transpose(inverse(u_model_mat)));
-	v_normal = normalize(normal_mat * in_normal);
+	v_normal = in_normal;
 	v_uv = in_uv;
 }

--- a/shaders/45/object.vert
+++ b/shaders/45/object.vert
@@ -17,6 +17,7 @@ out vec2 v_uv;
 
 void main() {
 	gl_Position = mvp_objects * u_model_mat * vec4(in_pos, 1.0);
-	v_normal = in_normal;
+	mat3 normal_mat = mat3(transpose(inverse(u_model_mat)));
+	v_normal = normalize(normal_mat * in_normal);
 	v_uv = in_uv;
 }

--- a/shaders/45/object.vert
+++ b/shaders/45/object.vert
@@ -1,0 +1,22 @@
+#version 450
+
+layout(location = 0) in vec3 in_pos;
+layout(location = 1) in vec3 in_normal;
+layout(location = 2) in vec2 in_uv;
+
+layout(std140, binding = 0) uniform ubo_mats {
+	mat4 mvp_mat_follow_view;
+	mat4 mvp_flat_sky_layer;
+	mat4 mvp_objects;
+};
+
+uniform mat4 u_model_mat;
+
+out vec3 v_normal;
+out vec2 v_uv;
+
+void main() {
+	gl_Position = mvp_objects * u_model_mat * vec4(in_pos, 1.0);
+	v_normal = in_normal;
+	v_uv = in_uv;
+}

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -832,6 +832,33 @@ void Folders_Init() {
 	Str_SPrintf(g_folders.res_folder_, 1024, "%s/res", buf);
 	Str_SPrintf(g_folders.shader_folder_, 1024, "%s/shaders", buf);
 
+	Str_Copy(g_folders.mef_folder_, 1024, "res/missions/location0/common/objects/");
+
+	char config_path[1024];
+#if defined(_WIN32)
+	Str_SPrintf(config_path, 1024, "%s/bin/config.ini", buf);
+#else
+	Str_SPrintf(config_path, 1024, "%s/bin/config.ini", buf);
+#endif
+
+	char* text = nullptr;
+	if (File_LoadText(config_path, text)) {
+		char* ptr = text;
+		while (*ptr) {
+			if (strncmp(ptr, "MEFPath=", 8) == 0) {
+				ptr += 8;
+				int i = 0;
+				while (*ptr && *ptr != '\n' && *ptr != '\r' && i < 1023) {
+					g_folders.mef_folder_[i++] = *ptr++;
+				}
+				g_folders.mef_folder_[i] = '\0';
+				break;
+			}
+			ptr++;
+		}
+		File_FreeBuf(text);
+	}
+
 	// debug
 	/*
 	printf("res_folder:    \"%s\"\n", g_folders.res_folder_);

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -847,36 +847,11 @@ void Folders_Init() {
 		while (*ptr) {
 			if (strncmp(ptr, "MEFPath=", 8) == 0) {
 				ptr += 8;
-				char parsed_path[1024] = {};
 				int i = 0;
 				while (*ptr && *ptr != '\n' && *ptr != '\r' && i < 1023) {
-					parsed_path[i++] = *ptr++;
+					g_folders.mef_folder_[i++] = *ptr++;
 				}
-				parsed_path[i] = '\0';
-
-				// Resolve to absolute path if relative
-				bool is_absolute = false;
-#if defined(_WIN32)
-				// Check for drive letter (C:\) or UNC path (\\)
-				if ((parsed_path[0] != '\0' && parsed_path[1] == ':') ||
-				    (parsed_path[0] == '\\' && parsed_path[1] == '\\')) {
-					is_absolute = true;
-				}
-#else
-				// Check for absolute path on Unix
-				if (parsed_path[0] == '/') {
-					is_absolute = true;
-				}
-#endif
-				if (is_absolute) {
-					Str_Copy(g_folders.mef_folder_, 1024, parsed_path);
-				} else {
-					// Relative path: join with base directory
-					char absolute_path[1024];
-					Str_SPrintf(absolute_path, 1024, "%s/%s", buf, parsed_path);
-					Str_EraseDoubleDotsInPath(absolute_path);
-					Str_Copy(g_folders.mef_folder_, 1024, absolute_path);
-				}
+				g_folders.mef_folder_[i] = '\0';
 				break;
 			}
 			ptr++;

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -847,11 +847,36 @@ void Folders_Init() {
 		while (*ptr) {
 			if (strncmp(ptr, "MEFPath=", 8) == 0) {
 				ptr += 8;
+				char parsed_path[1024] = {};
 				int i = 0;
 				while (*ptr && *ptr != '\n' && *ptr != '\r' && i < 1023) {
-					g_folders.mef_folder_[i++] = *ptr++;
+					parsed_path[i++] = *ptr++;
 				}
-				g_folders.mef_folder_[i] = '\0';
+				parsed_path[i] = '\0';
+
+				// Resolve to absolute path if relative
+				bool is_absolute = false;
+#if defined(_WIN32)
+				// Check for drive letter (C:\) or UNC path (\\)
+				if ((parsed_path[0] != '\0' && parsed_path[1] == ':') ||
+				    (parsed_path[0] == '\\' && parsed_path[1] == '\\')) {
+					is_absolute = true;
+				}
+#else
+				// Check for absolute path on Unix
+				if (parsed_path[0] == '/') {
+					is_absolute = true;
+				}
+#endif
+				if (is_absolute) {
+					Str_Copy(g_folders.mef_folder_, 1024, parsed_path);
+				} else {
+					// Relative path: join with base directory
+					char absolute_path[1024];
+					Str_SPrintf(absolute_path, 1024, "%s/%s", buf, parsed_path);
+					Str_EraseDoubleDotsInPath(absolute_path);
+					Str_Copy(g_folders.mef_folder_, 1024, absolute_path);
+				}
 				break;
 			}
 			ptr++;

--- a/source/common.h
+++ b/source/common.h
@@ -344,6 +344,6 @@ public:
 	virtual void			LoadTerrainMatTex(const pic_s* pic) = 0;
 	virtual void			LoadTerrainLMPTex(const pic_s* pic) = 0;
 
-	virtual void			AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id) = 0;
+	virtual void			AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id, int level_no) = 0;
 
 };

--- a/source/common.h
+++ b/source/common.h
@@ -180,6 +180,7 @@ void	Pic_FreePics(pics_s & pics);
 struct folders_s {
 	char					res_folder_[1024];
 	char					shader_folder_[1024];
+	char					mef_folder_[1024];
 };
 
 extern folders_s	g_folders;
@@ -342,5 +343,7 @@ public:
 	virtual void			LoadFlatSkyLayerTex(int layer_no, const pic_s* pic) = 0;
 	virtual void			LoadTerrainMatTex(const pic_s* pic) = 0;
 	virtual void			LoadTerrainLMPTex(const pic_s* pic) = 0;
+
+	virtual void			AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id) = 0;
 
 };

--- a/source/level/level.cpp
+++ b/source/level/level.cpp
@@ -62,7 +62,7 @@ bool Level::Load(load_params_s& params, glm::vec3& start_pos, float& start_yaw) 
 		LoadFogInfo(qsc_objects, params.render_res_loader_);
 		LoadSkydomeInfo(qsc_objects, params.render_res_loader_);
 		LoadFlatSkyLayersInfo(qsc_objects, params.render_res_loader_);
-		LoadLevelObjects(qsc_objects, params.render_res_loader_);
+		LoadLevelObjects(qsc_objects, params.render_res_loader_, params.level_no_);
 
 		Terrain::load_params_s terrain_load_params = {
 			.level_no_ = params.level_no_,
@@ -567,7 +567,7 @@ dyn_cube_s* Level::GetDynCube(const double pos[3], int cube_lod_level, glm::ivec
 	return dyn_cube;
 }
 
-void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_res_loader) {
+void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_res_loader, int level_no) {
 	const QSC::func_s* qsc_funcs[4096];
 	int num_rigid = qsc_objects->FindFuncByStr("EditRigidObj", qsc_funcs);
 	for (int i = 0; i < num_rigid; i++) {
@@ -578,12 +578,12 @@ void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_re
 		float rx = 0, ry = 0, rz = 0;
 		const char* model_id = "";
 		while (arg) {
-			if (arg_idx == 3 && arg->type_ == QSC::arg_s::type_t::DBL) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 4 && arg->type_ == QSC::arg_s::type_t::DBL) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 5 && arg->type_ == QSC::arg_s::type_t::DBL) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 6 && arg->type_ == QSC::arg_s::type_t::DBL) rx = arg->dbl_;
-			if (arg_idx == 7 && arg->type_ == QSC::arg_s::type_t::DBL) ry = arg->dbl_;
-			if (arg_idx == 8 && arg->type_ == QSC::arg_s::type_t::DBL) rz = arg->dbl_;
+			if (arg_idx == 3) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 4) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 5) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 6) rx = arg->dbl_;
+			if (arg_idx == 7) ry = arg->dbl_;
+			if (arg_idx == 8) rz = arg->dbl_;
 			if (arg_idx == 9 && arg->type_ == QSC::arg_s::type_t::STR) {
 				model_id = arg->str_;
 			}
@@ -591,7 +591,7 @@ void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_re
 			arg_idx++;
 		}
 		if (model_id[0] != '\0') {
-			render_res_loader->AddLevelObject(glm::vec3(px, py, pz), rz, model_id);
+			render_res_loader->AddLevelObject(glm::vec3(px, py, pz), rz, model_id, level_no);
 		}
 	}
 
@@ -604,12 +604,12 @@ void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_re
 		float rx = 0, ry = 0, rz = 0;
 		const char* model_id = "";
 		while (arg) {
-			if (arg_idx == 3 && arg->type_ == QSC::arg_s::type_t::DBL) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 4 && arg->type_ == QSC::arg_s::type_t::DBL) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 5 && arg->type_ == QSC::arg_s::type_t::DBL) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 6 && arg->type_ == QSC::arg_s::type_t::DBL) rx = arg->dbl_;
-			if (arg_idx == 7 && arg->type_ == QSC::arg_s::type_t::DBL) ry = arg->dbl_;
-			if (arg_idx == 8 && arg->type_ == QSC::arg_s::type_t::DBL) rz = arg->dbl_;
+			if (arg_idx == 3) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 4) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 5) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 6) rx = arg->dbl_;
+			if (arg_idx == 7) ry = arg->dbl_;
+			if (arg_idx == 8) rz = arg->dbl_;
 			if (arg_idx == 9 && arg->type_ == QSC::arg_s::type_t::STR) {
 				model_id = arg->str_;
 			}
@@ -617,7 +617,7 @@ void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_re
 			arg_idx++;
 		}
 		if (model_id[0] != '\0') {
-			render_res_loader->AddLevelObject(glm::vec3(px, py, pz), rz, model_id);
+			render_res_loader->AddLevelObject(glm::vec3(px, py, pz), rz, model_id, level_no);
 		}
 	}
 }

--- a/source/level/level.cpp
+++ b/source/level/level.cpp
@@ -62,6 +62,7 @@ bool Level::Load(load_params_s& params, glm::vec3& start_pos, float& start_yaw) 
 		LoadFogInfo(qsc_objects, params.render_res_loader_);
 		LoadSkydomeInfo(qsc_objects, params.render_res_loader_);
 		LoadFlatSkyLayersInfo(qsc_objects, params.render_res_loader_);
+		LoadLevelObjects(qsc_objects, params.render_res_loader_);
 
 		Terrain::load_params_s terrain_load_params = {
 			.level_no_ = params.level_no_,
@@ -564,6 +565,61 @@ dyn_cube_s* Level::GetDynCube(const double pos[3], int cube_lod_level, glm::ivec
 	}
 
 	return dyn_cube;
+}
+
+void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_res_loader) {
+	const QSC::func_s* qsc_funcs[4096];
+	int num_rigid = qsc_objects->FindFuncByStr("EditRigidObj", qsc_funcs);
+	for (int i = 0; i < num_rigid; i++) {
+		const QSC::arg_s* arg = qsc_funcs[i]->args_;
+		// EditRigidObj: id, type, name, px, py, pz, rx, ry, rz, model_id
+		int arg_idx = 0;
+		float px = 0, py = 0, pz = 0;
+		float rx = 0, ry = 0, rz = 0;
+		const char* model_id = "";
+		while (arg) {
+			if (arg_idx == 3) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 4) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 5) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 6) rx = arg->dbl_;
+			if (arg_idx == 7) ry = arg->dbl_;
+			if (arg_idx == 8) rz = arg->dbl_;
+			if (arg_idx == 9 && arg->type_ == QSC::arg_s::type_t::STR) {
+				model_id = arg->str_;
+			}
+			arg = arg->next_;
+			arg_idx++;
+		}
+		if (model_id[0] != '\0') {
+			render_res_loader->AddLevelObject(glm::vec3(px, py, pz), rz, model_id);
+		}
+	}
+
+	int num_building = qsc_objects->FindFuncByStr("Building", qsc_funcs);
+	for (int i = 0; i < num_building; i++) {
+		const QSC::arg_s* arg = qsc_funcs[i]->args_;
+		// Building: id, type, name, px, py, pz, rx, ry, rz, model_id
+		int arg_idx = 0;
+		float px = 0, py = 0, pz = 0;
+		float rx = 0, ry = 0, rz = 0;
+		const char* model_id = "";
+		while (arg) {
+			if (arg_idx == 3) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 4) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 5) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 6) rx = arg->dbl_;
+			if (arg_idx == 7) ry = arg->dbl_;
+			if (arg_idx == 8) rz = arg->dbl_;
+			if (arg_idx == 9 && arg->type_ == QSC::arg_s::type_t::STR) {
+				model_id = arg->str_;
+			}
+			arg = arg->next_;
+			arg_idx++;
+		}
+		if (model_id[0] != '\0') {
+			render_res_loader->AddLevelObject(glm::vec3(px, py, pz), rz, model_id);
+		}
+	}
 }
 
 void Level::AddQTaskToDynCube(dyn_cube_s* dyn_cube, qtask_s* qtask) {

--- a/source/level/level.cpp
+++ b/source/level/level.cpp
@@ -578,12 +578,12 @@ void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_re
 		float rx = 0, ry = 0, rz = 0;
 		const char* model_id = "";
 		while (arg) {
-			if (arg_idx == 3) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 4) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 5) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 6) rx = arg->dbl_;
-			if (arg_idx == 7) ry = arg->dbl_;
-			if (arg_idx == 8) rz = arg->dbl_;
+			if (arg_idx == 3 && arg->type_ == QSC::arg_s::type_t::DBL) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 4 && arg->type_ == QSC::arg_s::type_t::DBL) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 5 && arg->type_ == QSC::arg_s::type_t::DBL) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 6 && arg->type_ == QSC::arg_s::type_t::DBL) rx = arg->dbl_;
+			if (arg_idx == 7 && arg->type_ == QSC::arg_s::type_t::DBL) ry = arg->dbl_;
+			if (arg_idx == 8 && arg->type_ == QSC::arg_s::type_t::DBL) rz = arg->dbl_;
 			if (arg_idx == 9 && arg->type_ == QSC::arg_s::type_t::STR) {
 				model_id = arg->str_;
 			}
@@ -604,12 +604,12 @@ void Level::LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_re
 		float rx = 0, ry = 0, rz = 0;
 		const char* model_id = "";
 		while (arg) {
-			if (arg_idx == 3) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 4) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 5) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
-			if (arg_idx == 6) rx = arg->dbl_;
-			if (arg_idx == 7) ry = arg->dbl_;
-			if (arg_idx == 8) rz = arg->dbl_;
+			if (arg_idx == 3 && arg->type_ == QSC::arg_s::type_t::DBL) px = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 4 && arg->type_ == QSC::arg_s::type_t::DBL) py = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 5 && arg->type_ == QSC::arg_s::type_t::DBL) pz = arg->dbl_ * RENDERER_MODEL_SCALE_DOWN;
+			if (arg_idx == 6 && arg->type_ == QSC::arg_s::type_t::DBL) rx = arg->dbl_;
+			if (arg_idx == 7 && arg->type_ == QSC::arg_s::type_t::DBL) ry = arg->dbl_;
+			if (arg_idx == 8 && arg->type_ == QSC::arg_s::type_t::DBL) rz = arg->dbl_;
 			if (arg_idx == 9 && arg->type_ == QSC::arg_s::type_t::STR) {
 				model_id = arg->str_;
 			}

--- a/source/level/level.h
+++ b/source/level/level.h
@@ -51,7 +51,7 @@ private:
 	void					LoadFogInfo(const QSC * qsc_objects, IRenderResLoader* render_res_loader);
 	void					LoadSkydomeInfo(const QSC* qsc_objects, IRenderResLoader* render_res_loader);
 	void					LoadFlatSkyLayersInfo(const QSC* qsc_objects, IRenderResLoader* render_res_loader);
-	void					LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_res_loader);
+	void					LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_res_loader, int level_no);
 
 	// pos range: [-2^30, 2^30]
 	dyn_cube_s *			GetDynCube(const double pos[3], int cube_lod_level, glm::ivec3& cube_ctr) override;

--- a/source/level/level.h
+++ b/source/level/level.h
@@ -51,6 +51,7 @@ private:
 	void					LoadFogInfo(const QSC * qsc_objects, IRenderResLoader* render_res_loader);
 	void					LoadSkydomeInfo(const QSC* qsc_objects, IRenderResLoader* render_res_loader);
 	void					LoadFlatSkyLayersInfo(const QSC* qsc_objects, IRenderResLoader* render_res_loader);
+	void					LoadLevelObjects(const QSC* qsc_objects, IRenderResLoader* render_res_loader);
 
 	// pos range: [-2^30, 2^30]
 	dyn_cube_s *			GetDynCube(const double pos[3], int cube_lod_level, glm::ivec3& cube_ctr) override;

--- a/source/mef.cpp
+++ b/source/mef.cpp
@@ -27,11 +27,6 @@ struct HSEM_chunk_s {
 #pragma pack(pop)
 
 bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
-	// Reset output model
-	out_model.type = 0;
-	out_model.vertices.clear();
-	out_model.submeshes.clear();
-
 	int32_t file_len = 0;
 	void* buf = nullptr;
 
@@ -65,10 +60,7 @@ bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
 		uint32_t chunk_size = *(uint32_t*)(ptr + 4);
 		ptr += 8;
 
-		if (ptr + chunk_size > end) {
-			File_FreeBuf(buf);
-			return false;
-		}
+		if (ptr + chunk_size > end) break;
 		uint8_t* chunk_data = ptr;
 		ptr += chunk_size;
 
@@ -80,61 +72,22 @@ bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
 		} else if (strcmp(tag, "D3DR") == 0) {
 			// Do nothing for now
 		} else if (strcmp(tag, "DNER") == 0) {
-			// Validate minimum chunk size for header
-			if (chunk_size < 12) {
-				File_FreeBuf(buf);
-				return false;
-			}
-
 			mef_submesh_s submesh;
 			float* fptr = (float*)chunk_data;
 			submesh.offset = glm::vec3(fptr[0], fptr[1], fptr[2]);
 
 			int16_t* sptr = (int16_t*)(chunk_data + 12);
-
-			// Validate we can read at least sptr[0]
-			if (chunk_size < 12 + 2) {
-				File_FreeBuf(buf);
-				return false;
-			}
-
 			int fn = sptr[0];
 
-			// Validate fn is non-negative and reasonable
-			if (fn < 0 || fn > 100000) {
-				File_FreeBuf(buf);
-				return false;
-			}
-
 			uint16_t* indices;
-			uint32_t header_bytes;
 			if (out_model.type == 3) { // Lightmap
-				header_bytes = 20; // 10 shorts
-				// Validate chunk size for header
-				if (chunk_size < 12 + header_bytes) {
-					File_FreeBuf(buf);
-					return false;
-				}
 				submesh.vertex_offset = sptr[4];
 				submesh.vertex_count = sptr[5];
-				indices = (uint16_t*)(chunk_data + 12 + 20);
+				indices = (uint16_t*)(chunk_data + 12 + 20); // 10 shorts = 20 bytes
 			} else { // Type 0/1
-				header_bytes = 16; // 8 shorts
-				// Validate chunk size for header
-				if (chunk_size < 12 + header_bytes) {
-					File_FreeBuf(buf);
-					return false;
-				}
 				submesh.vertex_offset = sptr[3];
 				submesh.vertex_count = sptr[4];
-				indices = (uint16_t*)(chunk_data + 12 + 16);
-			}
-
-			// Validate indices array size
-			uint32_t indices_bytes = fn * sizeof(uint16_t);
-			if (chunk_size < 12 + header_bytes + indices_bytes) {
-				File_FreeBuf(buf);
-				return false;
+				indices = (uint16_t*)(chunk_data + 12 + 16); // 8 shorts = 16 bytes
 			}
 
 			for (int i = 0; i < fn / 3; i++) {
@@ -149,13 +102,6 @@ bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
 
 		} else if (strcmp(tag, "XTRV") == 0) {
 			int vertex_size = (out_model.type == 0) ? 32 : 40;
-
-			// Validate chunk_size is a multiple of vertex_size
-			if (chunk_size % vertex_size != 0) {
-				File_FreeBuf(buf);
-				return false;
-			}
-
 			int vertex_count = chunk_size / vertex_size;
 
 			for (int i = 0; i < vertex_count; i++) {

--- a/source/mef.cpp
+++ b/source/mef.cpp
@@ -1,0 +1,126 @@
+#include "mef.h"
+
+#pragma pack(push, 1)
+
+struct HSEM_chunk_s {
+	uint32_t reserved0;
+	uint32_t year, month, day, hour, min, sec, ms;
+	uint32_t mt;
+	uint32_t reserved1[3];
+	float f[12];
+	uint16_t fn;
+	uint16_t vn;
+	uint16_t reserved6;
+	uint16_t cv;
+	uint16_t cf;
+	uint16_t reserved9;
+	float fc;
+	uint16_t mg;
+	uint16_t an;
+	uint16_t pv;
+	uint16_t pf;
+	uint16_t pn;
+	uint16_t _f;
+	uint8_t rs[20];
+};
+
+#pragma pack(pop)
+
+bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
+	int32_t file_len = 0;
+	void* buf = nullptr;
+
+	if (!File_LoadBinary(filepath, buf, file_len)) {
+		return false;
+	}
+
+	uint8_t* ptr = (uint8_t*)buf;
+	uint8_t* end = ptr + file_len;
+
+	// Read ILFF
+	if (file_len < 12) {
+		File_FreeBuf(buf);
+		return false;
+	}
+
+	if (memcmp(ptr, "ILFF", 4) != 0) {
+		File_FreeBuf(buf);
+		return false;
+	}
+	ptr += 8; // skip size
+	if (memcmp(ptr, "OCEM", 4) != 0) {
+		File_FreeBuf(buf);
+		return false;
+	}
+	ptr += 4;
+
+	while (ptr + 8 <= end) {
+		char tag[5] = {0};
+		memcpy(tag, ptr, 4);
+		uint32_t chunk_size = *(uint32_t*)(ptr + 4);
+		ptr += 8;
+
+		if (ptr + chunk_size > end) break;
+		uint8_t* chunk_data = ptr;
+		ptr += chunk_size;
+
+		if (strcmp(tag, "HSEM") == 0) {
+			if (chunk_size >= sizeof(HSEM_chunk_s)) {
+				HSEM_chunk_s* hsem = (HSEM_chunk_s*)chunk_data;
+				out_model.type = hsem->mt;
+			}
+		} else if (strcmp(tag, "D3DR") == 0) {
+			// Do nothing for now
+		} else if (strcmp(tag, "DNER") == 0) {
+			mef_submesh_s submesh;
+			float* fptr = (float*)chunk_data;
+			submesh.offset = glm::vec3(fptr[0], fptr[1], fptr[2]);
+
+			int16_t* sptr = (int16_t*)(chunk_data + 12);
+			int fn = sptr[0];
+
+			uint16_t* indices;
+			if (out_model.type == 3) { // Lightmap
+				submesh.vertex_offset = sptr[4];
+				submesh.vertex_count = sptr[5];
+				indices = (uint16_t*)(chunk_data + 12 + 20); // 10 shorts = 20 bytes
+			} else { // Type 0/1
+				submesh.vertex_offset = sptr[3];
+				submesh.vertex_count = sptr[4];
+				indices = (uint16_t*)(chunk_data + 12 + 16); // 8 shorts = 16 bytes
+			}
+
+			for (int i = 0; i < fn / 3; i++) {
+				mef_face_s face;
+				face.v0 = indices[i * 3];
+				face.v1 = indices[i * 3 + 1];
+				face.v2 = indices[i * 3 + 2];
+				submesh.faces.push_back(face);
+			}
+
+			out_model.submeshes.push_back(submesh);
+
+		} else if (strcmp(tag, "XTRV") == 0) {
+			int vertex_size = (out_model.type == 0) ? 32 : 40;
+			int vertex_count = chunk_size / vertex_size;
+
+			for (int i = 0; i < vertex_count; i++) {
+				uint8_t* vptr = chunk_data + i * vertex_size;
+				mef_vert_s vert;
+				float* fptr = (float*)vptr;
+				vert.pos = glm::vec3(fptr[0], fptr[1], fptr[2]);
+				vert.normal = glm::vec3(fptr[3], fptr[4], fptr[5]);
+				vert.uv0 = glm::vec2(fptr[6], fptr[7]);
+				if (vertex_size == 40) {
+					vert.uv1 = glm::vec2(fptr[8], fptr[9]);
+				} else {
+					vert.uv1 = glm::vec2(0.0f);
+				}
+				out_model.vertices.push_back(vert);
+			}
+		}
+	}
+
+	File_FreeBuf(buf);
+	return true;
+}

--- a/source/mef.cpp
+++ b/source/mef.cpp
@@ -27,6 +27,11 @@ struct HSEM_chunk_s {
 #pragma pack(pop)
 
 bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
+	// Reset output model
+	out_model.type = 0;
+	out_model.vertices.clear();
+	out_model.submeshes.clear();
+
 	int32_t file_len = 0;
 	void* buf = nullptr;
 
@@ -60,7 +65,10 @@ bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
 		uint32_t chunk_size = *(uint32_t*)(ptr + 4);
 		ptr += 8;
 
-		if (ptr + chunk_size > end) break;
+		if (ptr + chunk_size > end) {
+			File_FreeBuf(buf);
+			return false;
+		}
 		uint8_t* chunk_data = ptr;
 		ptr += chunk_size;
 
@@ -72,22 +80,61 @@ bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
 		} else if (strcmp(tag, "D3DR") == 0) {
 			// Do nothing for now
 		} else if (strcmp(tag, "DNER") == 0) {
+			// Validate minimum chunk size for header
+			if (chunk_size < 12) {
+				File_FreeBuf(buf);
+				return false;
+			}
+
 			mef_submesh_s submesh;
 			float* fptr = (float*)chunk_data;
 			submesh.offset = glm::vec3(fptr[0], fptr[1], fptr[2]);
 
 			int16_t* sptr = (int16_t*)(chunk_data + 12);
+
+			// Validate we can read at least sptr[0]
+			if (chunk_size < 12 + 2) {
+				File_FreeBuf(buf);
+				return false;
+			}
+
 			int fn = sptr[0];
 
+			// Validate fn is non-negative and reasonable
+			if (fn < 0 || fn > 100000) {
+				File_FreeBuf(buf);
+				return false;
+			}
+
 			uint16_t* indices;
+			uint32_t header_bytes;
 			if (out_model.type == 3) { // Lightmap
+				header_bytes = 20; // 10 shorts
+				// Validate chunk size for header
+				if (chunk_size < 12 + header_bytes) {
+					File_FreeBuf(buf);
+					return false;
+				}
 				submesh.vertex_offset = sptr[4];
 				submesh.vertex_count = sptr[5];
-				indices = (uint16_t*)(chunk_data + 12 + 20); // 10 shorts = 20 bytes
+				indices = (uint16_t*)(chunk_data + 12 + 20);
 			} else { // Type 0/1
+				header_bytes = 16; // 8 shorts
+				// Validate chunk size for header
+				if (chunk_size < 12 + header_bytes) {
+					File_FreeBuf(buf);
+					return false;
+				}
 				submesh.vertex_offset = sptr[3];
 				submesh.vertex_count = sptr[4];
-				indices = (uint16_t*)(chunk_data + 12 + 16); // 8 shorts = 16 bytes
+				indices = (uint16_t*)(chunk_data + 12 + 16);
+			}
+
+			// Validate indices array size
+			uint32_t indices_bytes = fn * sizeof(uint16_t);
+			if (chunk_size < 12 + header_bytes + indices_bytes) {
+				File_FreeBuf(buf);
+				return false;
 			}
 
 			for (int i = 0; i < fn / 3; i++) {
@@ -102,6 +149,13 @@ bool MefLoader::LoadMEF(const char* filepath, mef_model_s& out_model) {
 
 		} else if (strcmp(tag, "XTRV") == 0) {
 			int vertex_size = (out_model.type == 0) ? 32 : 40;
+
+			// Validate chunk_size is a multiple of vertex_size
+			if (chunk_size % vertex_size != 0) {
+				File_FreeBuf(buf);
+				return false;
+			}
+
 			int vertex_count = chunk_size / vertex_size;
 
 			for (int i = 0; i < vertex_count; i++) {

--- a/source/mef.h
+++ b/source/mef.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "pch.h"
+
+struct mef_vert_s {
+	glm::vec3 pos;
+	glm::vec3 normal;
+	glm::vec2 uv0;
+	glm::vec2 uv1;
+};
+
+struct mef_face_s {
+	uint16_t v0, v1, v2;
+};
+
+struct mef_submesh_s {
+	glm::vec3 offset;
+	std::vector<mef_face_s> faces;
+	int vertex_offset;
+	int vertex_count;
+};
+
+struct mef_model_s {
+	uint32_t type;
+	std::vector<mef_vert_s> vertices;
+	std::vector<mef_submesh_s> submeshes;
+};
+
+class MefLoader {
+public:
+	static bool LoadMEF(const char* filepath, mef_model_s& out_model);
+};

--- a/source/renderer/renderer.cpp
+++ b/source/renderer/renderer.cpp
@@ -40,6 +40,10 @@ bool Renderer::Init() {
 		return false;
 	}
 
+	if (!objects_.Init()) {
+		return false;
+	}
+
 	// init default state
 	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 
@@ -65,6 +69,7 @@ bool Renderer::Init() {
 }
 
 void Renderer::Shutdown() {
+	objects_.Shutdown();
 	terrain_.Shutdown();
 	flat_sky_layers_.Shutdown();
 	skydome_.Shutdown();
@@ -76,6 +81,7 @@ void Renderer::Shutdown() {
 void Renderer::BeginLoadLevel() {
 	flat_sky_layers_.UnloadAllTexs();
 	terrain_.UnloadAllTexs();
+	objects_.ClearObjects();
 }
 
 void Renderer::SetupClearColor(const glm::vec4& color) {
@@ -105,6 +111,10 @@ void Renderer::LoadTerrainMatTex(const pic_s* pic) {
 
 void Renderer::LoadTerrainLMPTex(const pic_s* pic) {
 	terrain_.LoadLMPTex(pic);
+}
+
+void Renderer::AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id) {
+	objects_.AddObject(pos, yaw, model_id);
 }
 
 vert_flat_sky_layer_s* Renderer::MapFlatSkyLayersVB() {
@@ -154,6 +164,8 @@ void Renderer::Draw(const draw_params_s& params) {
 	if (params.draw_parts_ & DRAW_TERRAIN) {
 		terrain_.Draw(ubo_mats_, ubo_fog_, params.overlay_wireframe_, params.draw_terrain_options_, params.num_terrain_render_chunk_);
 	}
+
+	objects_.Draw(ubo_mats_);
 
 	GL_CHECK_ERROR;
 

--- a/source/renderer/renderer.cpp
+++ b/source/renderer/renderer.cpp
@@ -113,8 +113,8 @@ void Renderer::LoadTerrainLMPTex(const pic_s* pic) {
 	terrain_.LoadLMPTex(pic);
 }
 
-void Renderer::AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id) {
-	objects_.AddObject(pos, yaw, model_id);
+void Renderer::AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id, int level_no) {
+	objects_.AddObject(pos, yaw, model_id, level_no);
 }
 
 vert_flat_sky_layer_s* Renderer::MapFlatSkyLayersVB() {

--- a/source/renderer/renderer.h
+++ b/source/renderer/renderer.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "renderer_objects.h"
+
 /*
 ================================================================================
  Renderer
@@ -44,6 +46,8 @@ public:
 	void					LoadTerrainMatTex(const pic_s* pic) override;
 	void					LoadTerrainLMPTex(const pic_s* pic) override;
 
+	void					AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id) override;
+
 	vert_flat_sky_layer_s *	MapFlatSkyLayersVB();
 	void					UnmapFlatSkyLayersVB();
 
@@ -76,6 +80,7 @@ private:
 	Renderer_Skydome		skydome_;
 	Renderer_FlatSkyLayers	flat_sky_layers_;
 	Renderer_Terrain		terrain_;
+	Renderer_Objects		objects_;
 
 	void					SetupUBOMats(const view_define_s& vd);
 };

--- a/source/renderer/renderer.h
+++ b/source/renderer/renderer.h
@@ -46,7 +46,7 @@ public:
 	void					LoadTerrainMatTex(const pic_s* pic) override;
 	void					LoadTerrainLMPTex(const pic_s* pic) override;
 
-	void					AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id) override;
+	void					AddLevelObject(const glm::vec3& pos, float yaw, const char* model_id, int level_no) override;
 
 	vert_flat_sky_layer_s *	MapFlatSkyLayersVB();
 	void					UnmapFlatSkyLayersVB();

--- a/source/renderer/renderer_objects.cpp
+++ b/source/renderer/renderer_objects.cpp
@@ -44,15 +44,23 @@ void Renderer_Objects::Shutdown() {
 }
 
 void Renderer_Objects::AddObject(const glm::vec3& pos, float yaw, const char* model_id) {
+	// Validate model_id is not null
+	if (!model_id) {
+		return;
+	}
+
+	// Load model first and verify success
+	if (cached_models_.find(model_id) == cached_models_.end()) {
+		if (!LoadModel(model_id)) {
+			return;
+		}
+	}
+
 	render_object_s obj;
 	obj.pos = pos;
 	obj.yaw = yaw;
 	obj.model_id = model_id;
 	objects_.push_back(obj);
-
-	if (cached_models_.find(model_id) == cached_models_.end()) {
-		LoadModel(model_id);
-	}
 }
 
 void Renderer_Objects::ClearObjects() {
@@ -74,9 +82,19 @@ bool Renderer_Objects::LoadModel(const std::string& model_id) {
 	std::vector<uint16_t> indices;
 	for (const auto& submesh : mef.submeshes) {
 		for (const auto& face : submesh.faces) {
-			indices.push_back(face.v0 + submesh.vertex_offset);
-			indices.push_back(face.v1 + submesh.vertex_offset);
-			indices.push_back(face.v2 + submesh.vertex_offset);
+			// Check for overflow when adding vertex_offset
+			uint32_t idx0 = (uint32_t)face.v0 + (uint32_t)submesh.vertex_offset;
+			uint32_t idx1 = (uint32_t)face.v1 + (uint32_t)submesh.vertex_offset;
+			uint32_t idx2 = (uint32_t)face.v2 + (uint32_t)submesh.vertex_offset;
+
+			if (idx0 > 0xFFFF || idx1 > 0xFFFF || idx2 > 0xFFFF) {
+				// Skip faces with out-of-range indices
+				continue;
+			}
+
+			indices.push_back((uint16_t)idx0);
+			indices.push_back((uint16_t)idx1);
+			indices.push_back((uint16_t)idx2);
 		}
 	}
 	cached.index_count = indices.size();
@@ -125,6 +143,7 @@ void Renderer_Objects::Draw(GLuint ubo_mats) {
 	GLint ubo_idx = glGetUniformBlockIndex(shader_prog_, "ubo_mats");
 	if (ubo_idx != GL_INVALID_INDEX) {
 		glUniformBlockBinding(shader_prog_, ubo_idx, 0);
+		glBindBufferBase(GL_UNIFORM_BUFFER, 0, ubo_mats);
 	}
 
 	GLint u_model_mat = glGetUniformLocation(shader_prog_, "u_model_mat");

--- a/source/renderer/renderer_objects.cpp
+++ b/source/renderer/renderer_objects.cpp
@@ -43,36 +43,50 @@ void Renderer_Objects::Shutdown() {
 	cached_models_.clear();
 }
 
-void Renderer_Objects::AddObject(const glm::vec3& pos, float yaw, const char* model_id) {
-	// Validate model_id is not null
-	if (!model_id) {
-		return;
-	}
-
-	// Load model first and verify success
-	if (cached_models_.find(model_id) == cached_models_.end()) {
-		if (!LoadModel(model_id)) {
-			return;
-		}
-	}
-
+void Renderer_Objects::AddObject(const glm::vec3& pos, float yaw, const char* model_id, int level_no) {
 	render_object_s obj;
 	obj.pos = pos;
 	obj.yaw = yaw;
 	obj.model_id = model_id;
 	objects_.push_back(obj);
+
+	if (cached_models_.find(model_id) == cached_models_.end()) {
+		LoadModel(model_id, level_no);
+	}
 }
 
 void Renderer_Objects::ClearObjects() {
 	objects_.clear();
 }
 
-bool Renderer_Objects::LoadModel(const std::string& model_id) {
+bool Renderer_Objects::LoadModel(const std::string& model_id, int level_no) {
 	char path[1024];
-	Str_SPrintf(path, 1024, "%s%s.mef", g_folders.mef_folder_, model_id.c_str());
-
 	mef_model_s mef;
-	if (!MefLoader::LoadMEF(path, mef)) {
+	bool loaded = false;
+
+	// Location 1: res/missions/location0/level<N>/models/<model>.mef
+	Str_SPrintf(path, 1024, "%s/missions/location0/level%d/models/%s.mef", g_folders.res_folder_, level_no, model_id.c_str());
+	if (MefLoader::LoadMEF(path, mef)) {
+		loaded = true;
+	}
+
+	if (!loaded) {
+		// Location 2: res/missions/location0/common/models/<model>.mef
+		Str_SPrintf(path, 1024, "%s/missions/location0/common/models/%s.mef", g_folders.res_folder_, model_id.c_str());
+		if (MefLoader::LoadMEF(path, mef)) {
+			loaded = true;
+		}
+	}
+
+	if (!loaded) {
+		// Location 3: Config fallback
+		Str_SPrintf(path, 1024, "%s%s.mef", g_folders.mef_folder_, model_id.c_str());
+		if (MefLoader::LoadMEF(path, mef)) {
+			loaded = true;
+		}
+	}
+
+	if (!loaded) {
 		return false;
 	}
 
@@ -82,19 +96,9 @@ bool Renderer_Objects::LoadModel(const std::string& model_id) {
 	std::vector<uint16_t> indices;
 	for (const auto& submesh : mef.submeshes) {
 		for (const auto& face : submesh.faces) {
-			// Check for overflow when adding vertex_offset
-			uint32_t idx0 = (uint32_t)face.v0 + (uint32_t)submesh.vertex_offset;
-			uint32_t idx1 = (uint32_t)face.v1 + (uint32_t)submesh.vertex_offset;
-			uint32_t idx2 = (uint32_t)face.v2 + (uint32_t)submesh.vertex_offset;
-
-			if (idx0 > 0xFFFF || idx1 > 0xFFFF || idx2 > 0xFFFF) {
-				// Skip faces with out-of-range indices
-				continue;
-			}
-
-			indices.push_back((uint16_t)idx0);
-			indices.push_back((uint16_t)idx1);
-			indices.push_back((uint16_t)idx2);
+			indices.push_back(face.v0 + submesh.vertex_offset);
+			indices.push_back(face.v1 + submesh.vertex_offset);
+			indices.push_back(face.v2 + submesh.vertex_offset);
 		}
 	}
 	cached.index_count = indices.size();
@@ -143,7 +147,6 @@ void Renderer_Objects::Draw(GLuint ubo_mats) {
 	GLint ubo_idx = glGetUniformBlockIndex(shader_prog_, "ubo_mats");
 	if (ubo_idx != GL_INVALID_INDEX) {
 		glUniformBlockBinding(shader_prog_, ubo_idx, 0);
-		glBindBufferBase(GL_UNIFORM_BUFFER, 0, ubo_mats);
 	}
 
 	GLint u_model_mat = glGetUniformLocation(shader_prog_, "u_model_mat");

--- a/source/renderer/renderer_objects.cpp
+++ b/source/renderer/renderer_objects.cpp
@@ -1,0 +1,147 @@
+#include "pch.h"
+#include "renderer_objects.h"
+#include <glm/gtc/type_ptr.hpp>
+
+Renderer_Objects::Renderer_Objects() : shader_prog_(0) {
+}
+
+Renderer_Objects::~Renderer_Objects() {
+	Shutdown();
+}
+
+bool Renderer_Objects::Init() {
+	char vert_path[1024];
+	char frag_path[1024];
+
+	Str_SPrintf(vert_path, 1024, "%s/object.vert", g_folders.shader_folder_);
+	Str_SPrintf(frag_path, 1024, "%s/object.frag", g_folders.shader_folder_);
+
+	const char* shader_filenames[SUPPORT_SHADER_COUNT] = {0};
+	shader_filenames[VERTEX_SHADER] = vert_path;
+	shader_filenames[FRAGMENT_SHADER] = frag_path;
+
+	gl_program_s prog;
+	if (!GL_CreateProgram(shader_filenames, prog)) {
+		return false;
+	}
+	shader_prog_ = prog.program_;
+
+	return true;
+}
+
+void Renderer_Objects::Shutdown() {
+	if (shader_prog_) {
+		glDeleteProgram(shader_prog_);
+		shader_prog_ = 0;
+	}
+
+	for (auto& pair : cached_models_) {
+		glDeleteBuffers(1, &pair.second.vbo);
+		glDeleteBuffers(1, &pair.second.ibo);
+		glDeleteVertexArrays(1, &pair.second.vao);
+	}
+	cached_models_.clear();
+}
+
+void Renderer_Objects::AddObject(const glm::vec3& pos, float yaw, const char* model_id) {
+	render_object_s obj;
+	obj.pos = pos;
+	obj.yaw = yaw;
+	obj.model_id = model_id;
+	objects_.push_back(obj);
+
+	if (cached_models_.find(model_id) == cached_models_.end()) {
+		LoadModel(model_id);
+	}
+}
+
+void Renderer_Objects::ClearObjects() {
+	objects_.clear();
+}
+
+bool Renderer_Objects::LoadModel(const std::string& model_id) {
+	char path[1024];
+	Str_SPrintf(path, 1024, "%s%s.mef", g_folders.mef_folder_, model_id.c_str());
+
+	mef_model_s mef;
+	if (!MefLoader::LoadMEF(path, mef)) {
+		return false;
+	}
+
+	cached_model_s cached;
+	cached.index_count = 0;
+
+	std::vector<uint16_t> indices;
+	for (const auto& submesh : mef.submeshes) {
+		for (const auto& face : submesh.faces) {
+			indices.push_back(face.v0 + submesh.vertex_offset);
+			indices.push_back(face.v1 + submesh.vertex_offset);
+			indices.push_back(face.v2 + submesh.vertex_offset);
+		}
+	}
+	cached.index_count = indices.size();
+
+	if (cached.index_count == 0 || mef.vertices.empty()) {
+		return false;
+	}
+
+	glGenVertexArrays(1, &cached.vao);
+	glGenBuffers(1, &cached.vbo);
+	glGenBuffers(1, &cached.ibo);
+
+	glBindVertexArray(cached.vao);
+
+	glBindBuffer(GL_ARRAY_BUFFER, cached.vbo);
+	glBufferData(GL_ARRAY_BUFFER, mef.vertices.size() * sizeof(mef_vert_s), mef.vertices.data(), GL_STATIC_DRAW);
+
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, cached.ibo);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint16_t), indices.data(), GL_STATIC_DRAW);
+
+	// pos
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(mef_vert_s), (void*)offsetof(mef_vert_s, pos));
+
+	// normal
+	glEnableVertexAttribArray(1);
+	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(mef_vert_s), (void*)offsetof(mef_vert_s, normal));
+
+	// uv0
+	glEnableVertexAttribArray(2);
+	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(mef_vert_s), (void*)offsetof(mef_vert_s, uv0));
+
+	glBindVertexArray(0);
+
+	cached_models_[model_id] = cached;
+
+	return true;
+}
+
+void Renderer_Objects::Draw(GLuint ubo_mats) {
+	if (objects_.empty()) return;
+
+	glUseProgram(shader_prog_);
+
+	// binding point 0 is used for ubo_mats (as configured in app)
+	GLint ubo_idx = glGetUniformBlockIndex(shader_prog_, "ubo_mats");
+	if (ubo_idx != GL_INVALID_INDEX) {
+		glUniformBlockBinding(shader_prog_, ubo_idx, 0);
+	}
+
+	GLint u_model_mat = glGetUniformLocation(shader_prog_, "u_model_mat");
+
+	for (const auto& obj : objects_) {
+		auto it = cached_models_.find(obj.model_id);
+		if (it == cached_models_.end()) continue;
+
+		glm::mat4 model_mat = glm::translate(glm::mat4(1.0f), obj.pos);
+		model_mat = glm::rotate(model_mat, obj.yaw, glm::vec3(0.0f, 0.0f, 1.0f));
+
+		glUniformMatrix4fv(u_model_mat, 1, GL_FALSE, glm::value_ptr(model_mat));
+
+		glBindVertexArray(it->second.vao);
+		glDrawElements(GL_TRIANGLES, it->second.index_count, GL_UNSIGNED_SHORT, 0);
+	}
+
+	glBindVertexArray(0);
+	glUseProgram(0);
+}

--- a/source/renderer/renderer_objects.h
+++ b/source/renderer/renderer_objects.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "pch.h"
+#include "mef.h"
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+struct render_object_s {
+	glm::vec3 pos;
+	float yaw;
+	std::string model_id;
+};
+
+class Renderer_Objects {
+public:
+	Renderer_Objects();
+	~Renderer_Objects();
+
+	bool Init();
+	void Shutdown();
+
+	void AddObject(const glm::vec3& pos, float yaw, const char* model_id);
+	void ClearObjects();
+
+	void Draw(GLuint ubo_mats);
+
+private:
+	struct cached_model_s {
+		GLuint vao;
+		GLuint vbo;
+		GLuint ibo;
+		int index_count;
+	};
+
+	std::vector<render_object_s> objects_;
+	std::unordered_map<std::string, cached_model_s> cached_models_;
+
+	GLuint shader_prog_;
+
+	bool LoadModel(const std::string& model_id);
+};

--- a/source/renderer/renderer_objects.h
+++ b/source/renderer/renderer_objects.h
@@ -20,7 +20,7 @@ public:
 	bool Init();
 	void Shutdown();
 
-	void AddObject(const glm::vec3& pos, float yaw, const char* model_id);
+	void AddObject(const glm::vec3& pos, float yaw, const char* model_id, int level_no);
 	void ClearObjects();
 
 	void Draw(GLuint ubo_mats);
@@ -38,5 +38,5 @@ private:
 
 	GLuint shader_prog_;
 
-	bool LoadModel(const std::string& model_id);
+	bool LoadModel(const std::string& model_id, int level_no);
 };


### PR DESCRIPTION
This change implements the full feature requested by the user: parsing the `MEF` files for 3D model data, reading the `EditRigidObj` and `Building` tags from the `QSC` scripts, and wiring them into the rendering pipeline so they appear natively in the terrain engine.

Changes:
- Added `bin/config.ini` to resolve paths dynamically to where MEF files will be loaded from (`res/missions/location0/common/objects/`).
- Created `source/mef.h` and `source/mef.cpp` to correctly deserialize binary MEF container ILFF data.
- Added code into `source/level/level.cpp` to parse QSC `func_s` arguments for position (`px, py, pz`) and yaw (`rz`) for the dynamic and static rigid objects.
- Added `Renderer_Objects` to hold the cache of VBOs and VAOs.
- Wrote GLSL fragment/vertex shaders for both 4.1 and 4.5.

---
*PR created automatically by Jules for task [17919912600755044835](https://jules.google.com/task/17919912600755044835) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Level objects are now loaded from level data and rendered in-scene with proper diffuse lighting.
  * Models can be loaded from MEF-format assets and are drawn with per-object transforms.

* **Configuration**
  * Added a configurable resource path in the runtime configuration to locate object assets.

* **Stability**
  * Renderer lifecycle improved to initialize, clear, and shutdown object rendering cleanly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/Project-IGI-Terrain/pull/1)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->